### PR TITLE
Issue #6: Fetch pool data from camelot

### DIFF
--- a/src/contracts/addreses.ts
+++ b/src/contracts/addreses.ts
@@ -1,4 +1,4 @@
-import { WETH, OP, WBTC, STONES, FTRG, TOTEM } from '../utils'
+import {WETH, WBTC, STONES, FTRG, ODG, OD} from '../utils'
 
 // All keys are mandatory
 export type ContractKey =
@@ -139,7 +139,7 @@ const tokens: Record<GebDeployment, TokenList> = {
             address: '0x007b1aC6B1894351cD5B025470119cf07a719d5b',
             decimals: 18,
             symbol: 'OD',
-            bytes32String: '',
+            bytes32String: OD,
             collateralJoin: '',
             collateralAuctionHouse: '',
             isCollateral: false,
@@ -148,7 +148,7 @@ const tokens: Record<GebDeployment, TokenList> = {
             address: '0x1A095c17f8503A79E754371EfBb232c1C0D9cb07',
             decimals: 18,
             symbol: 'ODG',
-            bytes32String: '',
+            bytes32String: ODG,
             collateralJoin: '',
             collateralAuctionHouse: '',
             isCollateral: false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,16 @@ import { BigNumberish, BigNumber, FixedNumber } from '@ethersproject/bignumber'
 // === Constants ===
 
 /**
+ * byte32 value for the "OD" collateral
+ */
+const OD = '0x4f44000000000000000000000000000000000000000000000000000000000000'
+
+/**
+ * byte32 value for the "ODG" collateral
+ */
+const ODG = '0x4f44470000000000000000000000000000000000000000000000000000000000'
+
+/**
  * byte32 value for the "ETH-A" collateral
  */
 const ETH_A = '0x4554482d41000000000000000000000000000000000000000000000000000000'
@@ -126,6 +136,8 @@ const getRequireString = (error: any): string | null => {
 
 export {
     // Constants
+    OD,
+    ODG,
     WETH,
     OP,
     ETH_A,


### PR DESCRIPTION
Closes #6 

not ready for merge--leaving comments here

## Description
- The balances are being calculated correctly but the market prices are not--this is because the currentPrice is not being populated for OD and ODG since they have no collateralJoin and collateralAuctionHouse an error is thrown on the app side here:

```
        this.tokenCollateralAuctionHouse = Object.values(tokenList).filter(token => token.isCollateral).reduce((accum, token) => {
            const collateralAuctionHouse = types.CollateralAuctionHouse__factory.connect(token.collateralAuctionHouse, signerOrProvider)
            return { ...accum, [token.symbol]: collateralAuctionHouse }
        }, {})
```

Also, I'm using wETH in this function for testing purposes but if we want to use ETH then we will have to calculate its balance and marketPrice in a different way because we can't use an ERC20 ABI to calculate the amount of ETH in a liquidity pool contract (ETH is not an ERC20 and has no balanceOf) & the currentPrice won't be calculated because ETH is not an asset that can be added to addresses.ts