### PR TITLE
Issue #18: settleEvents parsing error

### DIFF
--- a/src/auctions/auctions.ts
+++ b/src/auctions/auctions.ts
@@ -99,8 +99,11 @@ export class Auctions {
                 }, {})
 
                 const settled = settleEvents.reduce((accum: { [key: string]: boolean }, settled: any) => {
-                    const id = settled._id.toString()
-                    return { ...accum, [id]: true }
+                  if (!settled._id) {
+                    return accum;
+                  }
+                  const id = settled._id.toString()
+                  return { ...accum, [id]: true }
                 }, {})
 
                 const auctions = startAuction.map((auc: any) =>


### PR DESCRIPTION
Closes #18 

## Description
I added a null/undefined check to settled._id. Settled auctions were not loading because settled._id is not always defined.

## Screenshots

Before (settled auction doesn't load, note error in console)

<img width="1350" alt="parse before" src="https://github.com/open-dollar/od-sdk/assets/47253537/71a20546-1173-437f-bf9b-e295fcc4e67e">

After (app changes need to be merged too because this will cause a division by zero error otherwise) 

<img width="1061" alt="Screenshot 2023-11-16 at 2 13 07 PM" src="https://github.com/open-dollar/od-sdk/assets/47253537/020198b7-2632-4faf-8583-741638bb6ef6">
