### PR TITLE
Issue #34: querySubgraph should work with Render-deployed subgraphs

### DIFF
--- a/src/auctions/subgraph.ts
+++ b/src/auctions/subgraph.ts
@@ -5,12 +5,21 @@ export const querySubgraph = async (query: string, subgraph: string): Promise<Ar
         operationName: 'CollateralAuctionEvents',
         query,
     }
+
+    const headers: {
+        'content-type': string
+        Authorization?: string
+    } = {
+        'content-type': 'application/json',
+    }
+
+    if (subgraph.startsWith('https://api.studio.thegraph.com')) {
+        headers.Authorization = '<token>'
+    }
+
     const options = {
         method: 'POST',
-        headers: {
-            'content-type': 'application/json',
-            Authorization: '<token>',
-        },
+        headers: headers,
         body: JSON.stringify(graphqlQuery),
     }
     const response = await fetch(subgraph, options)


### PR DESCRIPTION
Closes #34 

## Description
- Only passes in auth header when subgraph is hosted by The Graph to avoid CORS errors

## Screenshots

Local subgraph works (files shown are in node_modules)

<img width="1080" alt="local subgraph works" src="https://github.com/open-dollar/od-sdk/assets/47253537/0f7b37da-8cc3-4af8-8cd3-5867d355fe50">

Hosted subgraph works

<img width="1314" alt="hosted subgraph works" src="https://github.com/open-dollar/od-sdk/assets/47253537/92cbad85-f7f4-42aa-ae02-fdfc9a273540">


