### PR TITLE
Issue #80: Include internal balance in virtualUserSafes

### DIFF
--- a/solidity/contracts/VirtualUserSafes.sol
+++ b/solidity/contracts/VirtualUserSafes.sol
@@ -23,6 +23,7 @@ interface ISAFEEngine {
     }
 
     function safes(bytes32 collateralType, address safe) external view returns (SafeDeposit memory _safe);
+    function tokenCollateral(bytes32 collateralType, address safe) external view returns (uint256);
 }
 
 contract VirtualUserSafes {
@@ -32,6 +33,7 @@ contract VirtualUserSafes {
         uint256 lockedCollateral;
         uint256 generatedDebt;
         bytes32 collateralType;
+        uint256 internalBalance;
     }
 
     constructor(
@@ -62,12 +64,14 @@ contract VirtualUserSafes {
             safesData = new SafeData[](safes.length);
             for (uint256 i = 0; i < safes.length; i++) {
                 ISAFEEngine.SafeDeposit memory _safeData = safeEngine.safes(_cTypes[i], safes[i]);
+                uint256 _internalBalance = safeEngine.tokenCollateral(_cTypes[i], safes[i]);
                 safesData[i] = SafeData(
                     safes[i],
                     ids[i],
                     _safeData.lockedCollateral,
                     _safeData.generatedDebt,
-                    _cTypes[i]
+                    _cTypes[i],
+                    _internalBalance
                 );
             }
         }

--- a/src/virtual/virtualUserSafes.ts
+++ b/src/virtual/virtualUserSafes.ts
@@ -8,7 +8,7 @@ interface SafeData {
     lockedCollateral: BigNumber
     generatedDebt: BigNumber
     collateralType: string
-    internalBalance?: BigNumber
+    internalBalance: BigNumber
 }
 
 export async function fetchUserSafes(geb: Geb, userAddress: string): Promise<[BigNumber, SafeData[]]> {
@@ -38,7 +38,8 @@ export async function fetchUserSafes(geb: Geb, userAddress: string): Promise<[Bi
                 uint256 id, 
                 uint256 lockedCollateral, 
                 uint256 generatedDebt, 
-                bytes32 collateralType
+                bytes32 collateralType,
+                uint256 internalBalance
                 )[]`,
         ],
         returnedData
@@ -47,16 +48,5 @@ export async function fetchUserSafes(geb: Geb, userAddress: string): Promise<[Bi
     const coinBalance = decoded[0]
     const safesData = decoded[1]
 
-    // Fetch the internal balance for each safe
-    const updatedSafesData = await Promise.all(
-        safesData.map(async (safe) => {
-            const internalBalance = await geb.contracts.safeEngine.tokenCollateral(safe.collateralType, safe.addy)
-            return {
-                ...safe,
-                internalBalance,
-            }
-        })
-    )
-
-    return [coinBalance, updatedSafesData]
+    return [coinBalance, safesData]
 }


### PR DESCRIPTION
Closes #80 

## Description
- Adds internal balance to fetchUserSafes as part of the response

## Screenshots

In the app in gebManager/index.ts we can log out the fetchUserSafes response to see internalBalance is included

<img width="1128" alt="Screenshot 2024-07-05 at 6 41 57 PM" src="https://github.com/open-dollar/od-sdk/assets/47253537/6b0e6c82-274a-4bbb-8cd3-5b3c8ff056d1">
